### PR TITLE
feat: generate resource names

### DIFF
--- a/example/proto/gen/typescript/einride/example/account/v1/index.ts
+++ b/example/proto/gen/typescript/einride/example/account/v1/index.ts
@@ -1,0 +1,91 @@
+// Example: 'tenants/{tenant}'
+export interface TenantResourceName {
+  tenant: string;
+  toString(): string;
+}
+
+interface TenantResourceNameConstructor {
+  parse(s: string): TenantResourceName;
+  from(tenant: string): TenantResourceName;
+}
+
+export const TenantResourceName: TenantResourceNameConstructor = {
+  parse(s: string): TenantResourceName {
+    const errPrefix = `parse resource name ${s} as account-example.einride.tech/Tenant`;
+    const segments = s.split("/")
+    if (segments.length !== 2) {
+      throw new Error(`${errPrefix}: invalid segment count ${segments.length} (expected 2)`)
+    }
+    if (segments[0] !== "tenants") {
+      throw new Error(`${errPrefix}: invalid constant segment ${segments[0]} (expected tenants)`)
+    }
+    const tenant = segments[1]
+    return this.from(tenant)
+  },
+
+  from(tenant: string): TenantResourceName {
+    if (tenant === "" || tenant.indexOf("/") > -1) {
+      throw new Error(`invalid variable segment for tenant: '${tenant}'`)
+    }
+    return {
+      tenant,
+      toString(): string {
+        // eslint-disable-next-line no-useless-concat
+        return "tenants" + "/" + tenant
+      },
+    }
+  },
+}
+
+// Example: 'tenants/{tenant}/users/{user}'
+export interface UserResourceName {
+  tenant: string;
+  user: string;
+  tenantResourceName(): TenantResourceName;
+  toString(): string;
+}
+
+interface UserResourceNameConstructor {
+  parse(s: string): UserResourceName;
+  from(tenant: string, user: string): UserResourceName;
+}
+
+export const UserResourceName: UserResourceNameConstructor = {
+  parse(s: string): UserResourceName {
+    const errPrefix = `parse resource name ${s} as account-example.einride.tech/User`;
+    const segments = s.split("/")
+    if (segments.length !== 4) {
+      throw new Error(`${errPrefix}: invalid segment count ${segments.length} (expected 4)`)
+    }
+    if (segments[0] !== "tenants") {
+      throw new Error(`${errPrefix}: invalid constant segment ${segments[0]} (expected tenants)`)
+    }
+    const tenant = segments[1]
+    if (segments[2] !== "users") {
+      throw new Error(`${errPrefix}: invalid constant segment ${segments[2]} (expected users)`)
+    }
+    const user = segments[3]
+    return this.from(tenant, user)
+  },
+
+  from(tenant: string, user: string): UserResourceName {
+    if (tenant === "" || tenant.indexOf("/") > -1) {
+      throw new Error(`invalid variable segment for tenant: '${tenant}'`)
+    }
+    if (user === "" || user.indexOf("/") > -1) {
+      throw new Error(`invalid variable segment for user: '${user}'`)
+    }
+    return {
+      tenant,
+      user,
+      tenantResourceName(): TenantResourceName {
+        return TenantResourceName.from(tenant)
+      },
+      toString(): string {
+        // eslint-disable-next-line no-useless-concat
+        return "tenants" + "/" + tenant + "/" + "users" + "/" + user
+      },
+    }
+  },
+}
+

--- a/example/proto/gen/typescript/einride/example/todo/v1/index.ts
+++ b/example/proto/gen/typescript/einride/example/todo/v1/index.ts
@@ -1,0 +1,156 @@
+// Example: 'tenants/{tenant}/users/{user}/todos/{todo}'
+export interface TodoResourceName {
+  tenant: string;
+  user: string;
+  todo: string;
+  userResourceName(): UserResourceName;
+  tenantResourceName(): TenantResourceName;
+  toString(): string;
+}
+
+interface TodoResourceNameConstructor {
+  parse(s: string): TodoResourceName;
+  from(tenant: string, user: string, todo: string): TodoResourceName;
+}
+
+export const TodoResourceName: TodoResourceNameConstructor = {
+  parse(s: string): TodoResourceName {
+    const errPrefix = `parse resource name ${s} as todo-example.einride.tech/Todo`;
+    const segments = s.split("/")
+    if (segments.length !== 6) {
+      throw new Error(`${errPrefix}: invalid segment count ${segments.length} (expected 6)`)
+    }
+    if (segments[0] !== "tenants") {
+      throw new Error(`${errPrefix}: invalid constant segment ${segments[0]} (expected tenants)`)
+    }
+    const tenant = segments[1]
+    if (segments[2] !== "users") {
+      throw new Error(`${errPrefix}: invalid constant segment ${segments[2]} (expected users)`)
+    }
+    const user = segments[3]
+    if (segments[4] !== "todos") {
+      throw new Error(`${errPrefix}: invalid constant segment ${segments[4]} (expected todos)`)
+    }
+    const todo = segments[5]
+    return this.from(tenant, user, todo)
+  },
+
+  from(tenant: string, user: string, todo: string): TodoResourceName {
+    if (tenant === "" || tenant.indexOf("/") > -1) {
+      throw new Error(`invalid variable segment for tenant: '${tenant}'`)
+    }
+    if (user === "" || user.indexOf("/") > -1) {
+      throw new Error(`invalid variable segment for user: '${user}'`)
+    }
+    if (todo === "" || todo.indexOf("/") > -1) {
+      throw new Error(`invalid variable segment for todo: '${todo}'`)
+    }
+    return {
+      tenant,
+      user,
+      todo,
+      userResourceName(): UserResourceName {
+        return UserResourceName.from(tenant, user)
+      },
+      tenantResourceName(): TenantResourceName {
+        return TenantResourceName.from(tenant)
+      },
+      toString(): string {
+        // eslint-disable-next-line no-useless-concat
+        return "tenants" + "/" + tenant + "/" + "users" + "/" + user + "/" + "todos" + "/" + todo
+      },
+    }
+  },
+}
+
+// Example: 'tenants/{tenant}/users/{user}'
+interface UserResourceName {
+  tenant: string;
+  user: string;
+  tenantResourceName(): TenantResourceName;
+  toString(): string;
+}
+
+interface UserResourceNameConstructor {
+  parse(s: string): UserResourceName;
+  from(tenant: string, user: string): UserResourceName;
+}
+
+const UserResourceName: UserResourceNameConstructor = {
+  parse(s: string): UserResourceName {
+    const errPrefix = `parse resource name ${s} as account-example.einride.tech/User`;
+    const segments = s.split("/")
+    if (segments.length !== 4) {
+      throw new Error(`${errPrefix}: invalid segment count ${segments.length} (expected 4)`)
+    }
+    if (segments[0] !== "tenants") {
+      throw new Error(`${errPrefix}: invalid constant segment ${segments[0]} (expected tenants)`)
+    }
+    const tenant = segments[1]
+    if (segments[2] !== "users") {
+      throw new Error(`${errPrefix}: invalid constant segment ${segments[2]} (expected users)`)
+    }
+    const user = segments[3]
+    return this.from(tenant, user)
+  },
+
+  from(tenant: string, user: string): UserResourceName {
+    if (tenant === "" || tenant.indexOf("/") > -1) {
+      throw new Error(`invalid variable segment for tenant: '${tenant}'`)
+    }
+    if (user === "" || user.indexOf("/") > -1) {
+      throw new Error(`invalid variable segment for user: '${user}'`)
+    }
+    return {
+      tenant,
+      user,
+      tenantResourceName(): TenantResourceName {
+        return TenantResourceName.from(tenant)
+      },
+      toString(): string {
+        // eslint-disable-next-line no-useless-concat
+        return "tenants" + "/" + tenant + "/" + "users" + "/" + user
+      },
+    }
+  },
+}
+
+// Example: 'tenants/{tenant}'
+interface TenantResourceName {
+  tenant: string;
+  toString(): string;
+}
+
+interface TenantResourceNameConstructor {
+  parse(s: string): TenantResourceName;
+  from(tenant: string): TenantResourceName;
+}
+
+const TenantResourceName: TenantResourceNameConstructor = {
+  parse(s: string): TenantResourceName {
+    const errPrefix = `parse resource name ${s} as account-example.einride.tech/Tenant`;
+    const segments = s.split("/")
+    if (segments.length !== 2) {
+      throw new Error(`${errPrefix}: invalid segment count ${segments.length} (expected 2)`)
+    }
+    if (segments[0] !== "tenants") {
+      throw new Error(`${errPrefix}: invalid constant segment ${segments[0]} (expected tenants)`)
+    }
+    const tenant = segments[1]
+    return this.from(tenant)
+  },
+
+  from(tenant: string): TenantResourceName {
+    if (tenant === "" || tenant.indexOf("/") > -1) {
+      throw new Error(`invalid variable segment for tenant: '${tenant}'`)
+    }
+    return {
+      tenant,
+      toString(): string {
+        // eslint-disable-next-line no-useless-concat
+        return "tenants" + "/" + tenant
+      },
+    }
+  },
+}
+

--- a/example/proto/src/einride/example/todo/v1/todo.proto
+++ b/example/proto/src/einride/example/todo/v1/todo.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package einride.example.todo.v1;
+
+option go_package = "github.com/einride/protoc-gen-aip-typescript/example/proto/gen/go/einride/example/todo/v1;exampletodov1";
+option java_multiple_files = true;
+option java_outer_classname = "TodoProto";
+option java_package = "tech.einride.example.todo.v1";
+
+import "google/api/annotations.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
+
+// A todo is owned by a user
+message Todo {
+  option (google.api.resource) = {
+    type: "todo-example.einride.tech/Todo"
+    pattern: "tenants/{tenant}/users/{user}/todos/{todo}"
+    singular: "todo"
+    plural: "todos"
+  };
+
+  // The resource name of the todo.
+  string name = 1;
+
+  // The creation timestamp of the resource.
+  google.protobuf.Timestamp create_time = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The last update timestamp of the resource.
+  //
+  // Updated when create/update/delete operation is performed.
+  google.protobuf.Timestamp update_time = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The deletion timestamp of the resource.
+  google.protobuf.Timestamp delete_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The display name of the todo.
+  string display_name = 5 [(google.api.field_behavior) = REQUIRED];
+
+  // The display name of the todo.
+  string description = 6;
+
+  // The labels on the todo.
+  map<string,string> labels = 7;
+}

--- a/example/proto/src/einride/example/todo/v1/todo_service.proto
+++ b/example/proto/src/einride/example/todo/v1/todo_service.proto
@@ -1,0 +1,111 @@
+syntax = "proto3";
+
+package einride.example.todo.v1;
+
+option go_package = "github.com/einride/protoc-gen-aip-typescript/example/proto/gen/go/einride/example/todo/v1;exampletodov1";
+option java_multiple_files = true;
+option java_outer_classname = "TodoServiceProto";
+option java_package = "tech.einride.example.todo.v1";
+
+import "einride/example/todo/v1/todo.proto";
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/timestamp.proto";
+
+// This API represents a simple todo service.
+service TodoService {
+  option (google.api.default_host) = "todo-example.einride.tech";
+
+  // Get a todo.
+  // See: https://google.aip.dev/131 (Standard methods: Get).
+  rpc GetTodo(GetTodoRequest) returns (Todo) {
+    option (google.api.http) = {
+      get: "/v1/{name=tenants/*/users/*/todo/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // List todos.
+  // See: https://google.aip.dev/132 (Standard methods: List).
+  rpc ListTodos(ListTodosRequest) returns (ListTodosResponse) {
+    option (google.api.http) = {
+      get: "/v1/{parent=tenants/*/users/*}/todos"
+    };
+  }
+
+  // Create a todo.
+  // See: https://google.aip.dev/133 (Standard methods: Create).
+  rpc CreateTodo(CreateTodoRequest) returns (Todo) {
+    option (google.api.http) = {
+      post: "/v1/{parent=tenants/*/users/*}"
+      body: "todo"
+    };
+    option (google.api.method_signature) = "todo";
+  }
+
+  // Update a todo.
+  // See: https://google.aip.dev/134 (Standard methods: Update).
+  rpc UpdateTodo(UpdateTodoRequest) returns (Todo) {
+    option (google.api.http) = {
+      patch: "/v1/{todo.name=tenants/*/users/*/todos/*}"
+      body: "todo"
+    };
+    option (google.api.method_signature) = "todo,update_mask";
+  }
+
+}
+
+// Request message for TodoService.GetTodo.
+message GetTodoRequest {
+  // The resource name of the todo to retrieve.
+  // Format: tenants/{tenant}/users/{user}/todos/{todo}
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "todo-example.einride.tech/Todo"
+  ];
+}
+
+// Request message for TodoService.ListTodos.
+message ListTodosRequest {
+  // Requested page size. Server may return fewer todos than requested.
+  // If unspecified, server will pick an appropriate default.
+  int32 page_size = 1;
+
+  // A token identifying a page of results the server should return.
+  // Typically, this is the value of
+  // [ListTodosResponse.next_page_token][einride.example.todo.v1.ListTodosResponse.next_page_token]
+  // returned from the previous call to `ListTodos` method.
+  string page_token = 2;
+}
+
+// Response message for TodoService.ListTodos.
+message ListTodosResponse {
+  // The list of todos.
+  repeated Todo todos = 1;
+
+  // A token to retrieve next page of results.  Pass this value in the
+  // [ListTodosRequest.page_token][einride.example.todo.v1.ListTodosRequest.page_token]
+  // field in the subsequent call to `ListTodos` method to retrieve the next
+  // page of results.
+  string next_page_token = 2;
+}
+
+// Request message for TodoService.CreateTodo.
+message CreateTodoRequest {
+  // The todo to create.
+  Todo todo = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Request message for TodoService.UpdateTodo.
+message UpdateTodoRequest {
+  // The todo to update with. The name must match or be empty.
+  // The todo's `name` field is used to identify the todo to be updated.
+  // Format: tenants/{tenant}/users/{user}/todos/{todo}
+  Todo todo = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The list of fields to be updated.
+  google.protobuf.FieldMask update_mask = 2;
+}

--- a/internal/codegen/file.go
+++ b/internal/codegen/file.go
@@ -1,0 +1,21 @@
+package codegen
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type File struct {
+	buf bytes.Buffer
+}
+
+func (f *File) P(v ...interface{}) {
+	for _, x := range v {
+		fmt.Fprint(&f.buf, x)
+	}
+	fmt.Fprintln(&f.buf)
+}
+
+func (f *File) Content() []byte {
+	return f.buf.Bytes()
+}

--- a/internal/plugin/generate.go
+++ b/internal/plugin/generate.go
@@ -1,0 +1,69 @@
+package plugin
+
+import (
+	"fmt"
+	"path"
+	"sort"
+
+	"github.com/einride/protoc-gen-aip-typescript/internal/codegen"
+	"github.com/einride/protoc-gen-aip-typescript/internal/plugin/resourcename"
+	"go.einride.tech/aip/reflect/aipreflect"
+	"go.einride.tech/aip/reflect/aipregistry"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
+)
+
+func Generate(request *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorResponse, error) {
+	var opts Options
+	if err := opts.Unmarshal(request.Parameter); err != nil {
+		return nil, err
+	}
+
+	generate := make(map[string]struct{})
+	for _, f := range request.FileToGenerate {
+		generate[f] = struct{}{}
+	}
+
+	protoFiles, err := protodesc.NewFiles(&descriptorpb.FileDescriptorSet{
+		File: request.ProtoFile,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create proto registry: %w", err)
+	}
+
+	aipRegistry, err := aipregistry.NewResources(protoFiles)
+	if err != nil {
+		return nil, fmt.Errorf("create aip registry: %w", err)
+	}
+	packageResources := make(map[string][]*aipreflect.ResourceDescriptor)
+	aipRegistry.RangeResources(func(descriptor *aipreflect.ResourceDescriptor) bool {
+		if _, ok := generate[descriptor.ParentFile]; !ok {
+			return true
+		}
+		dir := path.Dir(descriptor.ParentFile)
+		packageResources[dir] = append(packageResources[dir], descriptor)
+		return true
+	})
+
+	var response pluginpb.CodeGeneratorResponse
+	for pkg, resources := range packageResources {
+		resources := resources
+		sort.Slice(resources, func(i, j int) bool {
+			return resources[i].Type.Type() < resources[j].Type.Type()
+		})
+
+		var file codegen.File
+		if err := resourcename.GeneratePackage(&file, resources, aipRegistry); err != nil {
+			return nil, fmt.Errorf("generate resource name: %w", err)
+		}
+		response.File = append(response.File, &pluginpb.CodeGeneratorResponse_File{
+			Name:           proto.String(path.Join(pkg, opts.Filename)),
+			Content:        proto.String(string(file.Content())),
+			InsertionPoint: proto.String(opts.InsertionPoint),
+		})
+	}
+
+	return &response, nil
+}

--- a/internal/plugin/options.go
+++ b/internal/plugin/options.go
@@ -1,0 +1,54 @@
+package plugin
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Options struct {
+	// The filename the generator will output into.
+	// Defaults to `"index.ts"`.
+	Filename string
+
+	// The insertion point in the target file the generator
+	// use.
+	// Defaults to `""` (ie. no insertion point)
+	InsertionPoint string
+}
+
+func defaultOptions() Options {
+	return Options{
+		Filename:       "index.ts",
+		InsertionPoint: "",
+	}
+}
+
+func (o *Options) Unmarshal(s *string) error {
+	defaults := defaultOptions()
+	o.Filename = defaults.Filename
+	o.InsertionPoint = defaults.InsertionPoint
+
+	// no options specified
+	if s == nil {
+		return nil
+	}
+	str := *s
+
+	opts := strings.Split(str, ",")
+	for _, opt := range opts {
+		parts := strings.SplitN(opt, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid option [%s]: expected key and value", opt)
+		}
+		key, value := parts[0], parts[1]
+		switch key {
+		case "insertion_point":
+			o.InsertionPoint = value
+		case "filename":
+			o.Filename = value
+		default:
+			return fmt.Errorf("unknown option [%s]", opt)
+		}
+	}
+	return nil
+}

--- a/internal/plugin/resourcename/generate.go
+++ b/internal/plugin/resourcename/generate.go
@@ -1,0 +1,166 @@
+package resourcename
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/einride/protoc-gen-aip-typescript/internal/codegen"
+	"go.einride.tech/aip/reflect/aipreflect"
+)
+
+type resourceName struct {
+	export    bool
+	typeName  aipreflect.ResourceTypeName
+	pattern   aipreflect.ResourceNamePatternDescriptor
+	ancestors []resourceName
+}
+
+func (r resourceName) Generate(f *codegen.File) {
+	r.generateInterface(f)
+	r.generateConstructorInterface(f)
+	r.generateConstructor(f)
+}
+
+func (r resourceName) generateInterface(f *codegen.File) {
+	f.P("// Example: '", r.pattern.String(), "'")
+	f.P(r.maybeExport(), "interface ", interfaceName(r.typeName), " {")
+
+	// segment accessors
+	for _, seg := range r.pattern.Segments {
+		if !seg.Variable {
+			continue
+		}
+		f.P(t(1), variableSegName(seg.Value), ": string;")
+	}
+
+	// ancestor accessors
+	for _, ancestor := range r.ancestors {
+		f.P(t(1), ancestorAccessorName(ancestor.typeName), "(): ", interfaceName(ancestor.typeName), ";")
+	}
+
+	f.P(t(1), "toString(): string;")
+	f.P("}")
+	f.P()
+}
+
+func (r resourceName) generateConstructorInterface(f *codegen.File) {
+	f.P("interface ", constructorName(r.typeName), " {")
+	f.P(t(1), "parse(s: string): ", interfaceName(r.typeName), ";")
+	f.P(t(1), "from(", fromArgsDecl(r.pattern), "): ", interfaceName(r.typeName), ";")
+	f.P("}")
+	f.P()
+}
+
+func (r resourceName) generateConstructor(f *codegen.File) {
+	f.P(r.maybeExport(), "const ", interfaceName(r.typeName), ": ", constructorName(r.typeName), " = {")
+	r.generateConstructorParse(f, 1)
+	f.P()
+	r.generateConstructorFrom(f, 1)
+	f.P("}")
+	f.P()
+}
+
+func (r resourceName) generateConstructorParse(f *codegen.File, indent int) {
+	f.P(t(indent), "parse(s: string): ", interfaceName(r.typeName), " {")
+	f.P(t(indent+1), "const errPrefix = `parse resource name ${s} as ", r.typeName, "`;")
+	f.P(t(indent+1), "const segments = s.split(\"/\")")
+
+	isWrongLen := "segments.length !== " + strconv.Itoa(len(r.pattern.Segments))
+	wrongLenErr := "`${errPrefix}: " +
+		"invalid segment count ${segments.length} " +
+		"(expected " + strconv.Itoa(len(r.pattern.Segments)) + ")`"
+	f.P(t(indent+1), "if (", isWrongLen, ") {")
+	f.P(t(indent+2), "throw new Error(", wrongLenErr, ")")
+	f.P(t(indent+1), "}")
+
+	for i, segment := range r.pattern.Segments {
+		if segment.Variable {
+			f.P(t(indent+1), "const ", variableSegName(segment.Value), " = segments[", i, "]")
+		} else {
+			isWrongConstSegment := "segments[" + strconv.Itoa(i) + "] !== " + strconv.Quote(segment.Value)
+			wrongConstSegmentErr := "`${errPrefix}: " +
+				"invalid constant segment ${segments[" + strconv.Itoa(i) + "]} " +
+				"(expected " + segment.Value + ")`"
+			f.P(t(indent+1), "if (", isWrongConstSegment, ") {")
+			f.P(t(indent+2), "throw new Error(", wrongConstSegmentErr, ")")
+			f.P(t(indent+1), "}")
+		}
+	}
+	f.P(t(indent+1), "return this.from(", fromArgs(r.pattern), ")")
+	f.P(t(indent), "},")
+}
+
+func (r resourceName) generateConstructorFrom(f *codegen.File, indent int) {
+	f.P(t(indent+0), "from(", fromArgsDecl(r.pattern), "): ", interfaceName(r.typeName), " {")
+	for _, seg := range r.pattern.Segments {
+		if !seg.Variable {
+			continue
+		}
+		isEmpty := variableSegName(seg.Value) + " === \"\""
+		containsSlash := variableSegName(seg.Value) + ".indexOf(\"/\") > -1"
+		invalidVariableSegmentErr := "`invalid variable segment for " + seg.Value + ": " +
+			"'${" + variableSegName(seg.Value) + "}'`"
+		f.P(t(indent+1), "if (", isEmpty, " || ", containsSlash, ") {")
+		f.P(t(indent+2), "throw new Error(", invalidVariableSegmentErr, ")")
+		f.P(t(indent+1), "}")
+	}
+	f.P(t(indent+1), "return {")
+	// segment accessors
+	for _, seg := range r.pattern.Segments {
+		if !seg.Variable {
+			continue
+		}
+		f.P(t(indent+2), variableSegName(seg.Value), ",")
+	}
+	// ancestor accessors
+	for _, ancestor := range r.ancestors {
+		f.P(t(indent+2), ancestorAccessorName(ancestor.typeName), "(): ", interfaceName(ancestor.typeName), " {")
+		f.P(t(indent+3), "return ", interfaceName(ancestor.typeName), ".from(", fromArgs(ancestor.pattern), ")")
+		f.P(t(indent+2), "},")
+	}
+	// toString
+	var toStringParts []string
+	for _, seg := range r.pattern.Segments {
+		if seg.Variable {
+			toStringParts = append(toStringParts, variableSegName(seg.Value))
+		} else {
+			toStringParts = append(toStringParts, strconv.Quote(seg.Value))
+		}
+	}
+	f.P(t(indent+2), "toString(): string {")
+	f.P(t(indent+3), "// eslint-disable-next-line no-useless-concat")
+	f.P(t(indent+3), "return ", strings.Join(toStringParts, " + \"/\" + "))
+	f.P(t(indent+2), "},")
+	f.P(t(indent+1), "}")
+	f.P(t(indent+0), "},")
+}
+
+func (r resourceName) maybeExport() string {
+	if r.export {
+		return "export "
+	}
+	return ""
+}
+
+func fromArgsDecl(pattern aipreflect.ResourceNamePatternDescriptor) string {
+	args := make([]string, 0, len(pattern.Segments))
+	for _, seg := range pattern.Segments {
+		if !seg.Variable {
+			continue
+		}
+		args = append(args, fmt.Sprintf("%s: string", variableSegName(seg.Value)))
+	}
+	return strings.Join(args, ", ")
+}
+
+func fromArgs(pattern aipreflect.ResourceNamePatternDescriptor) string {
+	args := make([]string, 0, len(pattern.Segments))
+	for _, seg := range pattern.Segments {
+		if !seg.Variable {
+			continue
+		}
+		args = append(args, variableSegName(seg.Value))
+	}
+	return strings.Join(args, ", ")
+}

--- a/internal/plugin/resourcename/helpers.go
+++ b/internal/plugin/resourcename/helpers.go
@@ -1,0 +1,9 @@
+package resourcename
+
+import (
+	"strings"
+)
+
+func t(indent int) string {
+	return strings.Repeat("  ", indent)
+}

--- a/internal/plugin/resourcename/main.go
+++ b/internal/plugin/resourcename/main.go
@@ -1,0 +1,64 @@
+package resourcename
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/einride/protoc-gen-aip-typescript/internal/codegen"
+	"go.einride.tech/aip/reflect/aipreflect"
+	"go.einride.tech/aip/reflect/aipregistry"
+)
+
+func GeneratePackage(
+	f *codegen.File,
+	resources []*aipreflect.ResourceDescriptor,
+	registry *aipregistry.Resources,
+) error {
+	if len(resources) == 0 {
+		return nil
+	}
+
+	pkg := path.Dir(resources[0].ParentFile)
+
+	// keep track of what resource names have been generated in the package
+	seen := make(map[aipreflect.ResourceTypeName]struct{})
+	queue := resources
+
+	for len(queue) > 0 {
+		resource := queue[0]
+		queue = queue[1:]
+
+		if _, ok := seen[resource.Type]; ok {
+			continue
+		}
+		seen[resource.Type] = struct{}{}
+
+		// no support for multiple resource name definitions
+		name := resource.Names[0]
+
+		ancestors := make([]resourceName, 0, len(name.Ancestors))
+		for _, ancestor := range name.Ancestors {
+			ancestorResource, ok := registry.FindResourceByType(ancestor)
+			if !ok {
+				return fmt.Errorf("unable to find resource type: %s", ancestor)
+			}
+			_ = pkg
+			ancestors = append(ancestors, resourceName{
+				typeName: ancestor,
+				pattern:  ancestorResource.Names[0].Pattern,
+			})
+			queue = append(queue, ancestorResource)
+		}
+
+		// resource declarations "imported" from other packages
+		// should not be re-exported.
+		shouldExport := path.Dir(resource.ParentFile) == pkg
+		resourceName{
+			export:    shouldExport,
+			typeName:  name.Type,
+			pattern:   name.Pattern,
+			ancestors: ancestors,
+		}.Generate(f)
+	}
+	return nil
+}

--- a/internal/plugin/resourcename/names.go
+++ b/internal/plugin/resourcename/names.go
@@ -1,0 +1,25 @@
+package resourcename
+
+import (
+	"strings"
+
+	"github.com/stoewer/go-strcase"
+	"go.einride.tech/aip/reflect/aipreflect"
+)
+
+func interfaceName(resource aipreflect.ResourceTypeName) string {
+	return resource.Type() + "ResourceName"
+}
+
+func ancestorAccessorName(resource aipreflect.ResourceTypeName) string {
+	ifi := interfaceName(resource)
+	return strings.ToLower(string(ifi[0])) + ifi[1:]
+}
+
+func constructorName(resource aipreflect.ResourceTypeName) string {
+	return interfaceName(resource) + "Constructor"
+}
+
+func variableSegName(value string) string {
+	return strcase.LowerCamelCase(value)
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/einride/protoc-gen-aip-typescript/internal/plugin"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/pluginpb"
 )
@@ -26,8 +27,11 @@ func run() error {
 	if err := proto.Unmarshal(in, req); err != nil {
 		return err
 	}
-	var resp pluginpb.CodeGeneratorResponse
-	out, err := proto.Marshal(&resp)
+	resp, err := plugin.Generate(req)
+	if err != nil {
+		return err
+	}
+	out, err := proto.Marshal(resp)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Generates helpers for working with resource names. Currently only
supports the "top-level" resource name declaration, as that is what we
most commonly use.

Example usage (this will be put in README in coming commit):

```ts
import { TenantResourceName } from "....."
const name = TenantResourceName.parse("tenants/1")
console.log(name.tenant)      // 1
console.log(name.toString())  // tenants/1

const name = TenantResourceName.from("1")
console.log(name.tenant)       // 1
console.log(name.toString())  // tenants/1
```

The generated code also have helpers for traversing up the resource
hierarchy:

```ts
import { UserResourceName } from "....."

const name = UserResourceName.parse("tenants/1/users/1")
console.log(name.toString())                         // tenants/1/users/1
console.log(name.tenantResourceName().toString)  // tenants/1
```

The generator supports configuration for insertion points, in order to
append to an already existing generated file.
