### PR TITLE
feat: support noUncheckedIndexedAccess tsconfig rule

### DIFF
--- a/example/proto/gen/typescript/einride/example/account/v1/index.ts
+++ b/example/proto/gen/typescript/einride/example/account/v1/index.ts
@@ -19,7 +19,7 @@ export const TenantResourceName: TenantResourceNameConstructor = {
     if (segments[0] !== "tenants") {
       throw new Error(`${errPrefix}: invalid constant segment ${segments[0]} (expected tenants)`)
     }
-    const tenant = segments[1]
+    const tenant = segments[1] ?? ""
     return this.from(tenant)
   },
 
@@ -60,11 +60,11 @@ export const UserResourceName: UserResourceNameConstructor = {
     if (segments[0] !== "tenants") {
       throw new Error(`${errPrefix}: invalid constant segment ${segments[0]} (expected tenants)`)
     }
-    const tenant = segments[1]
+    const tenant = segments[1] ?? ""
     if (segments[2] !== "users") {
       throw new Error(`${errPrefix}: invalid constant segment ${segments[2]} (expected users)`)
     }
-    const user = segments[3]
+    const user = segments[3] ?? ""
     return this.from(tenant, user)
   },
 

--- a/example/proto/gen/typescript/einride/example/todo/v1/index.ts
+++ b/example/proto/gen/typescript/einride/example/todo/v1/index.ts
@@ -23,15 +23,15 @@ export const TodoResourceName: TodoResourceNameConstructor = {
     if (segments[0] !== "tenants") {
       throw new Error(`${errPrefix}: invalid constant segment ${segments[0]} (expected tenants)`)
     }
-    const tenant = segments[1]
+    const tenant = segments[1] ?? ""
     if (segments[2] !== "users") {
       throw new Error(`${errPrefix}: invalid constant segment ${segments[2]} (expected users)`)
     }
-    const user = segments[3]
+    const user = segments[3] ?? ""
     if (segments[4] !== "todos") {
       throw new Error(`${errPrefix}: invalid constant segment ${segments[4]} (expected todos)`)
     }
-    const todo = segments[5]
+    const todo = segments[5] ?? ""
     return this.from(tenant, user, todo)
   },
 
@@ -86,11 +86,11 @@ const UserResourceName: UserResourceNameConstructor = {
     if (segments[0] !== "tenants") {
       throw new Error(`${errPrefix}: invalid constant segment ${segments[0]} (expected tenants)`)
     }
-    const tenant = segments[1]
+    const tenant = segments[1] ?? ""
     if (segments[2] !== "users") {
       throw new Error(`${errPrefix}: invalid constant segment ${segments[2]} (expected users)`)
     }
-    const user = segments[3]
+    const user = segments[3] ?? ""
     return this.from(tenant, user)
   },
 
@@ -136,7 +136,7 @@ const TenantResourceName: TenantResourceNameConstructor = {
     if (segments[0] !== "tenants") {
       throw new Error(`${errPrefix}: invalid constant segment ${segments[0]} (expected tenants)`)
     }
-    const tenant = segments[1]
+    const tenant = segments[1] ?? ""
     return this.from(tenant)
   },
 

--- a/internal/plugin/resourcename/generate.go
+++ b/internal/plugin/resourcename/generate.go
@@ -76,7 +76,7 @@ func (r resourceName) generateConstructorParse(f *codegen.File, indent int) {
 
 	for i, segment := range r.pattern.Segments {
 		if segment.Variable {
-			f.P(t(indent+1), "const ", variableSegName(segment.Value), " = segments[", i, "]")
+			f.P(t(indent+1), "const ", variableSegName(segment.Value), " = segments[", i, "] ?? \"\"")
 		} else {
 			isWrongConstSegment := "segments[" + strconv.Itoa(i) + "] !== " + strconv.Quote(segment.Value)
 			wrongConstSegmentErr := "`${errPrefix}: " +


### PR DESCRIPTION
In https://github.com/einride/tsconfig v2, `noUncheckedIndexedAccess` is enabled. Here's one implication:

```ts
const foo = ["bar"]
const baz = foo[1]
```

With `noUncheckedIndexedAccess` disabled, type of `baz` is `string`, which is dangerous, since it doesn't take the length of the array into account. In reality `foo[1]` is `undefined`, which means `foo[1].toLowerCase()` would be fine from a typing perspective, but result in runtime error.

With `noUncheckedIndexedAccess` enabled, type of `baz` is `string | undefined` which is correct. Indexed array access always appends `undefined` in the resulting type.

However, this new rule doesn't work with https://github.com/einride/protoc-gen-typescript-aip right now, see example here: https://github.com/einride/template-web-app/pull/743

To support this new rule, we have to make sure type is `string` when using indexed array access. There are many ways to do this, but the easiest way is probably to append `?? ""`.